### PR TITLE
Add envs to help cargo to find libmysqlclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ included with the server distribution on Windows). Additionally, either
 
 The build script of the crate will attempt to find the lib path of
 libmysql-client using the following methods:
-
-- First, it will attempt to use pkg-config to locate it. All the config options,
+- First, if the environment variables MYSQLCLIENT_LIB_DIR and MYSQLCLIENT_INCLUDE_DIR are set, it will use their values
+- If the environment variable isn't set, it will attempt to use pkg-config to locate it. All the config options,
   such as `PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_ALL_STATIC` etc., of the crate
   [pkg-config](http://alexcrichton.com/pkg-config-rs/pkg_config/index.html)
   apply.

--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,9 @@ fn main() {
     if pkg_config::probe_library("mysqlclient").is_ok() {
         // pkg_config did everything for us
     } else {
-        if let Some(path) = mysql_config_variable("pkglibdir") {
+        let lib_dir = env::var("MYSQLCLIENT_LIB_DIR").ok()
+            .or_else(|| mysql_config_variable("pkglibdir"));
+        if let Some(path) = lib_dir {
             println!("cargo:rustc-link-search=native={}", path);
             println!("cargo:rustc-link-lib=mysqlclient");
         }
@@ -46,8 +48,8 @@ fn generate_bindgen_file() {
 }
 
 fn mysql_include_dir() -> String {
-    pkg_config::get_variable("mysqlclient", "includedir")
-        .ok()
+    env::var("MYSQLCLIENT_INCLUDE_DIR").ok()
+        .or_else(|| pkg_config::get_variable("mysqlclient", "includedir").ok())
         .or_else(|| mysql_config_variable("pkgincludedir"))
         .expect("Unable to locate `mysql.h`")
 }


### PR DESCRIPTION
This change makes libmysql-sys be consistent with pq-sys because pq-sys has PQ_LIB_DIR.