### PR TITLE
msvc/vcpkg dynamic builds now require explicit opt-in

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ environment:
       VCPKG_DEFAULT_TRIPLET: x64-windows-static
     - target: x86_64-pc-windows-msvc
       VCPKG_DEFAULT_TRIPLET: x64-windows
+      VCPKGRS_DYNAMIC: 1
 
 install:
   - curl -fsS --retry 3 --retry-connrefused -o rustup-init.exe https://win.rustup.rs/


### PR DESCRIPTION
Sorry to bug you again.

The build helper was changed to require explicit opt-in for linking dynamically, otherwise cargo install using the msvc toolchain would prefer dynamically linking if Vcpkg is installed resulting in binaries that won't work without a PATH adjustment. This commit makes the appveyor build opt-in.
