### PR TITLE
use newer vcpkg build helper that follows dependencies

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,7 @@ install:
   - if defined VCPKG_DEFAULT_TRIPLET git clone https://github.com/Microsoft/vcpkg c:\projects\vcpkg
   - if defined VCPKG_DEFAULT_TRIPLET c:\projects\vcpkg\bootstrap-vcpkg.bat
   - if defined VCPKG_DEFAULT_TRIPLET set VCPKG_ROOT=c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET echo yes > %VCPKG_ROOT%\Downloads\AlwaysAllowDownloads  
   - if defined VCPKG_DEFAULT_TRIPLET %VCPKG_ROOT%\vcpkg.exe install libmysql
 
 build: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ environment:
       VCPKG_DEFAULT_TRIPLET: x64-windows-static
     - target: x86_64-pc-windows-msvc
       VCPKG_DEFAULT_TRIPLET: x64-windows
+      VCPKGRS_DYNAMIC: 1
 
 install:
   - curl -fsS --retry 3 --retry-connrefused -o rustup-init.exe https://win.rustup.rs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ os:
   - linux
   - osx
 before_script:
-  - pip install 'travis-cargo<0.2' --user
-  - export PATH=$HOME/.local/bin:$PATH
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install mysql-connector-c ; fi
 
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ links = "mysqlclient"
 pkg-config = "0.3.9"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
-vcpkg = "0.2"
+vcpkg = "0.2.4"

--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,7 @@ fn main() {
         // pkg_config did everything for us
         return
     } else if try_vcpkg() {
+        // vcpkg did everything for us
         return;
     } else if let Ok(path) = env::var("MYSQLCLIENT_LIB_DIR") {
         println!("cargo:rustc-link-search=native={}", path);
@@ -40,17 +41,7 @@ fn mysql_config_variable(var_name: &str) -> Option<String> {
 
 #[cfg(target_env = "msvc")]
 fn try_vcpkg() -> bool {
-    if vcpkg::Config::new()
-        .lib_name("mysqlclient")
-        .probe("libmysql")
-        .is_ok() {
-        // found the static library - vcpkg did everything for us
-        return true;
-    } else if vcpkg::probe_package("libmysql").is_ok() {
-        // found the dynamic library - vcpkg did everything for us
-        return true;
-    }
-    false
+    vcpkg::find_package("libmysql").is_ok()
 }
 
 #[cfg(not(target_env = "msvc"))]


### PR DESCRIPTION
This fixes building on Windows using libraries from Vcpkg by using vcpkg::find_package() which also emits cargo metadata for dependencies of libmysql.

This PR also contains 3 commits to fix appveyor/travis tests.