### PR TITLE
Allow using libperconaserver

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,9 @@ fn main() {
     if pkg_config::probe_library("mysqlclient").is_ok() {
         // pkg_config did everything for us
         return
+    } else if pkg_config::probe_library("perconaserverclient").is_ok() {
+        // pkg_config did everything for us
+        return
     } else if try_vcpkg() {
         // vcpkg did everything for us
         return;


### PR DESCRIPTION
The libperconaserver library is a complete replacement for
libmysqlclient. Packages including percona-server often, but not always,
include a link overriding libmysqlclient. Notably, however, this link is
not included in the homebrew package percona-server on macOS. When using
that package, this configuration is required.