### PR TITLE
Fix buildtime_bindgen for non x86_64 architectures

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -118,6 +118,7 @@ fn parse_version(version: &str) {
                 Ok("aarch64")
             ))
     {
+        #[cfg(not(feature = "buildtime_bindgen"))]
         panic!(
             "mysqlclient-sys does not provide bundled bindings for {}\n\
                 Consider using the `buildtime_bindgen` feature or \


### PR DESCRIPTION
During some testing it appeared that the `buildtime_bindgen` feature still generates a panic even though it shouldn't when generating bindings for non x86_64 architectures.

Adding an extra `cfg` check to prevent this error.