### PR TITLE
Handle -R in mysql_config output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ mysql, mariadb ]
+        target: [mysql, mariadb]
         os: [ubuntu-latest, macos-13, macos-14, windows-2022]
         features: [default, buildtime_bindgen, bundled]
         install: [default]
         include:
-         - target: mysql
-           os: windows-2022
-           install: vcpkg
-           features: buildtime_bindgen
-         - target: mariadb
-           os: windows-2022
-           install: vcpkg
-           features: buildtime_bindgen
+          - target: mysql
+            os: windows-2022
+            install: vcpkg
+            features: buildtime_bindgen
+          - target: mariadb
+            os: windows-2022
+            install: vcpkg
+            features: buildtime_bindgen
         exclude:
           - target: mariadb
             features: bundled
@@ -100,14 +100,14 @@ jobs:
       - name: Install MySQL (MacOS M1)
         if: matrix.os == 'macos-14' && matrix.target == 'mysql' && matrix.features != 'bundled'
         run: |
-          brew install mysql@8.3
-          brew services start mysql@8.3
+          brew install mysql@8.4
+          brew services start mysql@8.4
           sleep 3
-          /opt/homebrew/opt/mysql@8.3/bin/mysql -e "create database diesel_test; create database diesel_unit_test;"
-          /opt/homebrew/opt/mysql@8.3/bin/mysql -e "create user runner@localhost; grant all on \`diesel_%\`.* to 'runner'@'localhost';"
-          echo "MYSQLCLIENT_LIB_DIR=/opt/homebrew/opt/mysql@8.3/lib" >> $GITHUB_ENV
-          echo "MYSQLCLIENT_INCLUDE_DIR=/opt/homebrew/opt/mysql@8.3/include/mysql" >> $GITHUB_ENV
-          echo "MYSQLCLIENT_VERSION=8.3" >> $GITHUB_ENV
+          /opt/homebrew/opt/mysql@8.4/bin/mysql -e "create database diesel_test; create database diesel_unit_test;"
+          /opt/homebrew/opt/mysql@8.4/bin/mysql -e "create user runner@localhost; grant all on \`diesel_%\`.* to 'runner'@'localhost';"
+          echo "MYSQLCLIENT_LIB_DIR=/opt/homebrew/opt/mysql@8.4/lib" >> $GITHUB_ENV
+          echo "MYSQLCLIENT_INCLUDE_DIR=/opt/homebrew/opt/mysql@8.4/include/mysql" >> $GITHUB_ENV
+          echo "MYSQLCLIENT_VERSION=8.4" >> $GITHUB_ENV
 
       - name: Install MariaDB latest (MacOS M1)
         if: matrix.os == 'macos-14' && matrix.target == 'mariadb'
@@ -138,7 +138,7 @@ jobs:
         if: runner.os == 'Windows' && matrix.target == 'mariadb' && matrix.install != 'vcpkg'
         shell: cmd
         run: |
-          curl -L https://ftp.osuosl.org/pub/mariadb/mariadb-11.4.2/winx64-packages/mariadb-11.4.2-winx64.zip -o library.zip
+          curl -L https://ftp.osuosl.org/pub/mariadb/mariadb-11.5.2/winx64-packages/mariadb-11.5.2-winx64.zip -o library.zip
           unzip library.zip
 
       - name: Install ${{ matrix.target }} (Windows vcpkg)
@@ -158,7 +158,7 @@ jobs:
         if: runner.os == 'Windows' && matrix.target == 'mariadb' && matrix.install == 'vcpkg'
         shell: bash
         run: |
-          echo "MYSQLCLIENT_VERSION=11.4" >> $GITHUB_ENV
+          echo "MYSQLCLIENT_VERSION=11.5" >> $GITHUB_ENV
 
       - name: Set variables for mysql (Windows)
         if: runner.os == 'Windows' && matrix.target == 'mysql' &&  matrix.features != 'bundled' && matrix.install != 'vcpkg'
@@ -174,12 +174,12 @@ jobs:
         if: runner.os == 'Windows' && matrix.target == 'mariadb' && matrix.install != 'vcpkg'
         shell: bash
         run: |
-          echo "MYSQLCLIENT_LIB_DIR=${{github.workspace}}/mariadb-11.4.2-winx64/lib/" >> $GITHUB_ENV
-          echo "MYSQLCLIENT_INCLUDE_DIR=${{github.workspace}}/mariadb-11.4.2-winx64/include/mysql/" >> $GITHUB_ENV
-          echo "MYSQLCLIENT_VERSION=11.4.2" >> $GITHUB_ENV
+          echo "MYSQLCLIENT_LIB_DIR=${{github.workspace}}/mariadb-11.5.2-winx64/lib/" >> $GITHUB_ENV
+          echo "MYSQLCLIENT_INCLUDE_DIR=${{github.workspace}}/mariadb-11.5.2-winx64/include/mysql/" >> $GITHUB_ENV
+          echo "MYSQLCLIENT_VERSION=11.5.2" >> $GITHUB_ENV
           echo "MYSQLCLIENT_LIBNAME=mariadbclient" >> $GITHUB_ENV
-          dir ./mariadb-11.4.2-winx64/lib
-          dir ./mariadb-11.4.2-winx64/include
+          dir ./mariadb-11.5.2-winx64/lib
+          dir ./mariadb-11.5.2-winx64/include
 
       - name: Windows setup (bundled)
         if: runner.os == 'Windows' && matrix.features == 'bundled'

--- a/build.rs
+++ b/build.rs
@@ -76,6 +76,8 @@ fn main() {
                 println!("cargo:rustc-link-lib={link_specifier}{lib}");
             } else if let Some(path) = part.strip_prefix("-L") {
                 println!("cargo:rustc-link-search=native={path}");
+            } else if let Some(path) = part.strip_prefix("-R") {
+                println!("cargo:rustc-link-arg=-Wl,-R{path}");
             } else {
                 panic!("Unexpected output from mysql_config: `{output}`");
             }

--- a/build.rs
+++ b/build.rs
@@ -116,7 +116,7 @@ fn mysql_config_variable(var_name: &str) -> Option<String> {
         .next()
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum MysqlVersion {
     Mysql5,
     Mysql80,
@@ -153,13 +153,13 @@ impl MysqlVersion {
         // libmariadb-dev 3.3.8 -> mariadb 10.x
         // Linux version becomes the full SONAME like 21.3.2 but MacOS is just the
         // major.
-        if version.starts_with("5.7.") || version.starts_with("20.") || version == "20" {
+        if version.starts_with("5.7") || version.starts_with("20.") || version == "20" {
             Some(Self::Mysql5)
-        } else if version.starts_with("8.0.") || version.starts_with("21.") || version == "21" {
+        } else if version.starts_with("8.0") || version.starts_with("21.") || version == "21" {
             Some(Self::Mysql80)
-        } else if version.starts_with("8.3.") || version.starts_with("23.") || version == "23" {
+        } else if version.starts_with("8.3") || version.starts_with("23.") || version == "23" {
             Some(Self::Mysql83)
-        } else if version.starts_with("8.4.") || version.starts_with("24.") || version == "24" {
+        } else if version.starts_with("8.4") || version.starts_with("24.") || version == "24" {
             Some(Self::Mysql84)
         } else if version.starts_with("10.")
             || version.starts_with("11.")
@@ -222,7 +222,8 @@ fn parse_version(version_str: &str) {
                 "mysqlclient-sys does not provide bundled bindings for libmysqlclient `{version_str}` \
                  for the target `{}`.
                  Consider using the `buildtime_bindgen` feature or \
-                 contribute bindings to the crate",
+                 contribute bindings to the crate\n\
+                 Debug information: (version: {version:?}, target_arch: {target_arch}, ptr_size: {ptr_size})",
                 std::env::var("TARGET").expect("Set by cargo")
             )
         }


### PR DESCRIPTION
When building on OmniOS, the build panics with:

```
  --- stderr
  thread 'main' panicked at /data/omnios-build/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mysqlclient-sys-0.4.0/build.rs:80:17:
  Unexpected output from mysql_config: `-L/opt/ooce/mariadb-10.7/lib/amd64 -R/opt/ooce/mariadb-10.7/lib/amd64 -lmariadb -lnsl -lsocket -ldl -lm -lssl -lcrypto -lz`
```

This is because the output of `mysql_config` includes a `-R` link option because the libraries are in a non-standard location. This patch handles converting `-R` to an appropriate option.