### PR TITLE
build mysqlclient-src with CLIENT_PLUGIN_AUTH for backward compatibility

### DIFF
--- a/mysqlclient-src/build.rs
+++ b/mysqlclient-src/build.rs
@@ -7,7 +7,9 @@ fn main() {
         .define("WITHOUT_SERVER", "ON")
         .define("WITH_SSL", openssl_dir)
         .define("WITH_EDITLINE", "bundled")
+        .define("WITH_AUTHENTICATION_CLIENT_PLUGINS", "yes")
         .build_target("mysqlclient");
+    
 
     if cfg!(feature = "with-asan") {
         config.define("WITH_ASAN", "ON");


### PR DESCRIPTION
Hey,

When trying to establish connection using mysqlclient-sys bundled and mysql_native_password, it fails with the following message.
```
Authentication plugin 'mysql_native_password' cannot be loaded: Dynamic loading not supported
```

Since 9.0.0
> The mysql_native_password authentication plugin, deprecated in MySQL 8.0, has been removed, and the server now rejects mysql_native authentication requests from older client programs which do not have CLIENT_PLUGIN_AUTH capability. For backward compatibility, mysql_native_password remains available on the client; the client-side built-in authentication plugin has been converted into a dynamically loadable plugin. 

https://dev.mysql.com/doc/relnotes/mysql/9.0/en/news-9-0-0.html#mysqld-9-0-0-deprecation-removal
https://bugs.mysql.com/bug.php?id=116616

This PR adds `WITH_AUTHENTICATION_CLIENT_PLUGINS` to build args for backward compatibility.

Should it be behind a feature ? feel free to ask if any change needed.

