### PR TITLE
Include bindings/wrapper.h in crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ links = "mysqlclient"
 edition = "2021"
 keywords = ["bindings", "libmysqlclient", "mysqlclient-sys"]
 categories = ["database", "external-ffi-bindings"]
-include = ["src/**/*.rs", "Cargo.toml", "bindings/**/*.rs", "README.md", "LICENSE-MIT", "LICENSE-APACHE", "build.rs"]
+include = ["src/**/*.rs", "Cargo.toml", "bindings/**/*.rs", "bindings/wrapper.h", "README.md", "LICENSE-MIT", "LICENSE-APACHE", "build.rs"]
 
 [build-dependencies]
 pkg-config = "0.3.9"


### PR DESCRIPTION
I am building this crate on riscv64 which does not have prebuilt bindings, the following error happens:

    thread 'main' (8765) panicked at /build/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mysqlclient-sys-0.5.1/build.rs:443:10:
    Unable to generate bindings: NotExist("bindings/wrapper.h")
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

It turns out that bindings/wrapper.h gets excluded from the crate when publishing. This PR includes it in the crate to fix builds with `--features buildtime_bindgen`