### PR TITLE
Allow bundled compile for musl targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,7 @@ jobs:
         compiler_target:
           [
             { os: ubuntu-latest, target: x86_64-unknown-linux-gnu },
-            { os: ubuntu-latest, target: x86_64-unknown-linux-musl },
             { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu },
-            { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl },
             { os: macos-15-intel, target: x86_64-apple-darwin },
             { os: macos-26, target: aarch64-apple-darwin },
             { os: windows-2025, target: x86_64-pc-windows-msvc },
@@ -44,6 +42,16 @@ jobs:
               { os: windows-2025, target: x86_64-pc-windows-msvc }
             install: vcpkg
             features: buildtime_bindgen
+          - target: mysql
+            compiler_target:
+              { os: ubuntu-latest, target: x86_64-unknown-linux-musl }
+            features: bundled
+            openssl: "-F openssl-sys/vendored"
+          - target: mysql
+            compiler_target:
+              { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl }
+            features: bundled
+            openssl: "-F openssl-sys/vendored"
         exclude:
           # Bundled builds never use MariaDB target
           - target: mariadb
@@ -112,7 +120,7 @@ jobs:
           echo "MYSQL_UNIT_TEST_DATABASE_URL=mysql://root:root@localhost/diesel_unit_test" >> $GITHUB_ENV
 
       - name: Install MySQL (MacOS Intel)
-        if: ${{ runner.os == 'macos-15-intel' && matrix.target == 'mysql' && !startsWith(matrix.features, 'bundled') }}
+        if: ${{ matrix.compiler_target.os == 'macos-15-intel' && matrix.target == 'mysql' && !startsWith(matrix.features, 'bundled') }}
         run: |
           brew update
           brew install mysql@8.0
@@ -124,13 +132,13 @@ jobs:
           ls /usr/local/opt/mysql@8.0/include/mysql
 
       - name: Install MariaDB 10.5 (MacOS Intel)
-        if: ${{ runner.os == 'macos-15-intel' && matrix.target == 'mariadb' }}
+        if: ${{ matrix.compiler_target.os == 'macos-15-intel' && matrix.target == 'mariadb' }}
         run: |
           brew install mariadb@10.6
           echo "PKG_CONFIG_PATH=/usr/local/opt/mariadb@10.6/lib/pkgconfig" >> $GITHUB_ENV
 
       - name: Install MySQL (MacOS M1)
-        if: ${{ runner.os == 'macos-26' && matrix.target == 'mysql' && !startsWith(matrix.features, 'bundled') }}
+        if: ${{ matrix.compiler_target.os == 'macos-26' && matrix.target == 'mysql' && !startsWith(matrix.features, 'bundled') }}
         run: |
           brew update
           brew install mysql@8.4
@@ -143,7 +151,7 @@ jobs:
           echo "MYSQLCLIENT_VERSION=8.4" >> $GITHUB_ENV
 
       - name: Install MariaDB latest (MacOS M1)
-        if: ${{ runner.os == 'macos-26' && matrix.target == 'mariadb' }}
+        if: ${{ matrix.compiler_target.os == 'macos-26' && matrix.target == 'mariadb' }}
         run: |
           brew update
           brew install mariadb@11.4
@@ -216,6 +224,13 @@ jobs:
           cargo --version
           rustc --version
 
+      - name: Setup musl toolchain (aarch64)
+        if: ${{ matrix.compiler_target.target == 'aarch64-unknown-linux-musl' ||  matrix.compiler_target.target == 'x86_64-unknown-linux-musl' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          echo "TARGET_CXX=g++" >> $GITHUB_ENV
+
       - name: Check
         shell: bash
         env:
@@ -256,7 +271,7 @@ jobs:
           cargo build --features "mysqlclient-sys/$FEATURES" $OPENSSL --target $TARGET
 
       - name: Generated bindings.rs
-        if: ${{ matrix.os != 'Windows' && !startsWith(matrix.features, 'bundled') }}
+        if: ${{ runner.os != 'Windows' && !startsWith(matrix.features, 'bundled') }}
         shell: bash
         run: |
           find . -name bindings.rs -ls -exec cat {} \;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,12 +224,14 @@ jobs:
           cargo --version
           rustc --version
 
-      - name: Setup musl toolchain (aarch64)
+      - name: Setup musl toolchain
         if: ${{ matrix.compiler_target.target == 'aarch64-unknown-linux-musl' ||  matrix.compiler_target.target == 'x86_64-unknown-linux-musl' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-          echo "TARGET_CXX=g++" >> $GITHUB_ENV
+          echo "TARGET_CXX=musl-gcc" >> $GITHUB_ENV
+          echo "TARGET_CC=musl-gcc" >> $GITHUB_ENV
+          echo "TARGET_LD=musl-gcc" >> $GITHUB_ENV
 
       - name: Check
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,23 +21,27 @@ jobs:
       fail-fast: false
       matrix:
         target: [mysql, mariadb]
-        os:
+        compiler_target:
           [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            macos-15-intel,
-            macos-26,
-            windows-2025,
+            { os: ubuntu-latest, target: x86_64-unknown-linux-gnu },
+            { os: ubuntu-latest, target: x86_64-unknown-linux-musl },
+            { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu },
+            { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-musl },
+            { os: macos-15-intel, target: x86_64-apple-darwin },
+            { os: macos-26, target: aarch64-apple-darwin },
+            { os: windows-2025, target: x86_64-pc-windows-msvc },
           ]
         features: [default, buildtime_bindgen, bundled]
         openssl: ["-F openssl-sys/vendored", ""]
         include:
           - target: mysql
-            os: windows-2025
+            compiler_target:
+              { os: windows-2025, target: x86_64-pc-windows-msvc }
             install: vcpkg
             features: buildtime_bindgen
           - target: mariadb
-            os: windows-2025
+            compiler_target:
+              { os: windows-2025, target: x86_64-pc-windows-msvc }
             install: vcpkg
             features: buildtime_bindgen
         exclude:
@@ -50,10 +54,11 @@ jobs:
           - features: buildtime_bindgen
             openssl: "-F openssl-sys/vendored"
           # Building without system openssl isn't useful on Windows hosts
-          - os: windows-2025
+          - compiler_target:
+              { os: windows-2025, target: x86_64-pc-windows-msvc }
             openssl: ""
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.compiler_target.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -107,7 +112,7 @@ jobs:
           echo "MYSQL_UNIT_TEST_DATABASE_URL=mysql://root:root@localhost/diesel_unit_test" >> $GITHUB_ENV
 
       - name: Install MySQL (MacOS Intel)
-        if: ${{ matrix.os == 'macos-15-intel' && matrix.target == 'mysql' && !startsWith(matrix.features, 'bundled') }}
+        if: ${{ runner.os == 'macos-15-intel' && matrix.target == 'mysql' && !startsWith(matrix.features, 'bundled') }}
         run: |
           brew update
           brew install mysql@8.0
@@ -119,13 +124,13 @@ jobs:
           ls /usr/local/opt/mysql@8.0/include/mysql
 
       - name: Install MariaDB 10.5 (MacOS Intel)
-        if: ${{ matrix.os == 'macos-15-intel' && matrix.target == 'mariadb' }}
+        if: ${{ runner.os == 'macos-15-intel' && matrix.target == 'mariadb' }}
         run: |
           brew install mariadb@10.6
           echo "PKG_CONFIG_PATH=/usr/local/opt/mariadb@10.6/lib/pkgconfig" >> $GITHUB_ENV
 
       - name: Install MySQL (MacOS M1)
-        if: ${{ matrix.os == 'macos-26' && matrix.target == 'mysql' && !startsWith(matrix.features, 'bundled') }}
+        if: ${{ runner.os == 'macos-26' && matrix.target == 'mysql' && !startsWith(matrix.features, 'bundled') }}
         run: |
           brew update
           brew install mysql@8.4
@@ -138,7 +143,7 @@ jobs:
           echo "MYSQLCLIENT_VERSION=8.4" >> $GITHUB_ENV
 
       - name: Install MariaDB latest (MacOS M1)
-        if: ${{ matrix.os == 'macos-26' && matrix.target == 'mariadb' }}
+        if: ${{ runner.os == 'macos-26' && matrix.target == 'mariadb' }}
         run: |
           brew update
           brew install mariadb@11.4
@@ -148,7 +153,7 @@ jobs:
           echo "PKG_CONFIG_PATH=/opt/homebrew/opt/mariadb@11.4/lib/pkgconfig" >> $GITHUB_ENV
 
       - name: Env MacOS
-        if: (matrix.os == 'macos-15-intel' || matrix.os == 'macos-15') && !startsWith(matrix.features, 'bundled')
+        if: (runner.os == 'macos-15-intel' || runner.os == 'macos-15') && !startsWith(matrix.features, 'bundled')
         run: |
           echo "MYSQL_DATABASE_URL=mysql://runner@localhost/diesel_test" >> $GITHUB_ENV
           echo "MYSQL_EXAMPLE_DATABASE_URL=mysql://runner@localhost/diesel_example" >> $GITHUB_ENV
@@ -201,8 +206,11 @@ jobs:
           echo OPENSSL_SRC_PERL=C:/Strawberry/perl/bin/perl >> $GITHUB_ENV
 
       - name: Install rust toolchain
+        env:
+          TARGET: ${{ matrix.compiler_target.target }}
         run: |
           rustup update stable
+          rustup target add $TARGET
           rustup override set stable
           rustup component add rustfmt
           cargo --version
@@ -213,16 +221,18 @@ jobs:
         env:
           FEATURES: ${{ matrix.features }}
           OPENSSL: ${{ matrix.openssl }}
+          TARGET: ${{ matrix.compiler_target.target }}
         run: |
-          cargo check --no-default-features --features "$FEATURES" $OPENSSL --verbose
+          cargo check --no-default-features --features "$FEATURES" $OPENSSL --verbose --target $TARGET
 
       - name: Tests
         shell: bash
         env:
           FEATURES: ${{ matrix.features }}
           OPENSSL: ${{ matrix.openssl }}
+          TARGET: ${{ matrix.compiler_target.target }}
         run: |
-          cargo test --no-default-features --features "$FEATURES" $OPENSSL
+          cargo test --no-default-features --features "$FEATURES" $OPENSSL --target $TARGET
 
       - name: Test compile diesel
         shell: bash
@@ -231,6 +241,7 @@ jobs:
         env:
           FEATURES: ${{ matrix.features }}
           OPENSSL: ${{ matrix.openssl }}
+          TARGET: ${{ matrix.compiler_target.target }}
         run: |
           cargo new test_diesel
           cd test_diesel
@@ -242,7 +253,7 @@ jobs:
           cat Cargo.toml
           echo "use diesel::prelude::*;" > src/main.rs
           echo "fn main() { MysqlConnection::establish(\"foo\").unwrap(); }" >> src/main.rs
-          cargo build --features "mysqlclient-sys/$FEATURES" $OPENSSL
+          cargo build --features "mysqlclient-sys/$FEATURES" $OPENSSL --target $TARGET
 
       - name: Generated bindings.rs
         if: ${{ matrix.os != 'Windows' && !startsWith(matrix.features, 'bundled') }}
@@ -255,8 +266,9 @@ jobs:
         if: ${{ matrix.features == 'bundled' }}
         env:
           OPENSSL: ${{ matrix.openssl }}
+          TARGET: ${{ matrix.compiler_target.target }}
         run: |
           rm -rf test_diesel
           git reset --hard HEAD
           cd mysqlclient-src
-          cargo package $OPENSSL
+          cargo package $OPENSSL --target $TARGET

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All user visible changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/), as described
 for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
 
+## [0.2.2] 2026-07-10
+
+* Fix cross compiling libmysqlclient-src to musl targets
+
 ## [0.2.1] 2026-06-19
 
 * Don't search for ncurse/readline and rpc libraries while building mysqlclient-src

--- a/mysqlclient-src/Cargo.toml
+++ b/mysqlclient-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysqlclient-src"
-version = "0.2.1+9.5.0"
+version = "0.2.2+9.5.0"
 edition = "2021"
 build = "build.rs"
 description = "Bundled version of libmysqlclient"

--- a/mysqlclient-src/build.rs
+++ b/mysqlclient-src/build.rs
@@ -24,13 +24,19 @@ fn main() {
         config.define("WITH_ASAN", "ON");
     }
 
-    if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV");
+    if target_env.as_deref() == Ok("msvc") {
         // rust links the release MVSC runtime
         // also for debug builds. If we let
         // cmake choose debug/release builds
         // based on the underlying cargo build
         // version that results in linker errors
         config.profile("Release");
+    } else if target_env.as_deref() == Ok("musl") {
+        // when (cross) compiling for musl targets
+        // you need an extra flag to tell the
+        // compiler it is building a musl target
+        config.define("LINUX_ALPINE", "1");
     }
 
     let mut dst = config.build();

--- a/mysqlclient-src/build.rs
+++ b/mysqlclient-src/build.rs
@@ -20,23 +20,27 @@ fn main() {
         config.define("WITH_SSL", openssl_dir.unwrap());
     }
 
-    if cfg!(feature = "with-asan") {
+    if std::env::var("CARGO_FEATURE_WITH_ASAN").is_ok() {
         config.define("WITH_ASAN", "ON");
     }
 
     let target_env = std::env::var("CARGO_CFG_TARGET_ENV");
-    if target_env.as_deref() == Ok("msvc") {
-        // rust links the release MVSC runtime
-        // also for debug builds. If we let
-        // cmake choose debug/release builds
-        // based on the underlying cargo build
-        // version that results in linker errors
-        config.profile("Release");
-    } else if target_env.as_deref() == Ok("musl") {
-        // when (cross) compiling for musl targets
-        // you need an extra flag to tell the
-        // compiler it is building a musl target
-        config.define("LINUX_ALPINE", "1");
+    match target_env.as_deref() {
+        Ok("msvc") => {
+            // rust links the release MVSC runtime
+            // also for debug builds. If we let
+            // cmake choose debug/release builds
+            // based on the underlying cargo build
+            // version that results in linker errors
+            config.profile("Release");
+        }
+        Ok("musl") => {
+            // when (cross) compiling for musl targets
+            // you need an extra flag to tell the
+            // compiler it is building a musl target
+            config.define("LINUX_ALPINE", "1");
+        }
+        _ => {}
     }
 
     let mut dst = config.build();


### PR DESCRIPTION
When trying to use the `mysqlclient-sys/bundled` bundled feature cross compiling for the musl target, it will fail because it can't find specific symbols.

There is a special cmake flag for this `LINUX_ALPINE` which will trigger some changes to allow compiling for the musl targets.

This only happens with cross-compiling since the `CMakeLists.txt` does some host checking if it is Alpine or not. But with cross-compiling this might not be the case if you compile from an Ubuntu host or container.